### PR TITLE
fix a recent assert in tabs selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Demo game for Flutter and Flutter Sprites.
 The objectives for this game include:
 
 * Prove that Flutter's performance is fast.
-* Prove that Flutter's widget system is versatle.
+* Prove that Flutter's widget system is versatile.
 * Prove that Flutter's feature set is rich and capable.
 
 This game is very much a work in progress. If you have any

--- a/lib/game_objects.dart
+++ b/lib/game_objects.dart
@@ -95,7 +95,7 @@ class LevelLabel extends GameObject {
       "L E V E L $level",
       new TextStyle(
         textAlign: TextAlign.center,
-        color:new Color(0xffffffff),
+        color: new Color(0xffffffff),
         fontSize: 24.0,
         fontWeight: FontWeight.w600
       ));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -263,13 +263,13 @@ class MainSceneState extends State<MainScene> {
   void initState() {
     super.initState();
 
-    _tabSelection = new TabBarSelection(index: 0);
+    _tabSelection = new TabBarSelection(index: 0, maxIndex: 2);
   }
 
   Widget build(BuildContext context) {
     return new CoordinateSystem(
       systemSize: new Size(320.0, 320.0),
-      child:new DefaultTextStyle(
+      child: new DefaultTextStyle(
         style: new TextStyle(fontSize:20.0),
         child: new Stack(<Widget>[
           new MainSceneBackground(),


### PR DESCRIPTION
Fix a recently introduced assertion about specifying the `maxIndex` param to `TabBarSelection`; this was throwing an exception on startup.